### PR TITLE
improve "is depended on by" wording for bad plan

### DIFF
--- a/Stackage/CheckBuildPlan.hs
+++ b/Stackage/CheckBuildPlan.hs
@@ -142,7 +142,7 @@ instance Show BadBuildPlan where
             [ display dep
             , "-"
             , display version
-            , " depended on by:"
+            , " is out of bounds for:"
             ]
 
         showUser :: (PkgUser, VersionRange) -> Text


### PR DESCRIPTION
I find the wording "package-version is depended on by:  consumer-version (range) @mntnr" a bit confusing.

This changes it to say "is out of bounds for:" instead, which I think is more intelligible/less confusing.
(Maybe it could even say "version bounds", or there might be an even clearer wording?)