### PR TITLE
Remove stackage-cli, build with base 4.9

### DIFF
--- a/Stackage/PackageIndex.hs
+++ b/Stackage/PackageIndex.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveFunctor      #-}
@@ -88,7 +89,9 @@ data SimplifiedPackageDescription = SimplifiedPackageDescription
     }
     deriving Generic
 
+#if !MIN_VERSION_base(4, 9, 0)
 deriving instance Generic Version
+#endif
 
 instance Store SimplifiedPackageDescription
 instance Store a => Store (CondTree ConfVar [Dependency] a)

--- a/app/stackage-build-plan.hs
+++ b/app/stackage-build-plan.hs
@@ -7,9 +7,9 @@ import qualified Data.Text.Lazy            as TL
 import           Data.Text.Lazy.Builder    (toLazyText)
 import qualified Data.Text.Lazy.IO         as TLIO
 import           Options.Applicative
+import           Options.Applicative.Simple (simpleOptions, simpleVersion)
 import           Paths_stackage_curator    (version)
 import           Stackage.ShowBuildPlan
-import           Stackage.CLI              (simpleOptions, simpleVersion)
 
 main :: IO ()
 main = do

--- a/app/stackage.hs
+++ b/app/stackage.hs
@@ -6,8 +6,8 @@ import           Control.Monad
 import qualified Data.Text                    as T
 import           Data.Text.Read               (decimal)
 import           Options.Applicative
+import           Options.Applicative.Simple   (simpleOptions, simpleVersion, addCommand)
 import           Paths_stackage_curator       (version)
-import           Stackage.CLI
 import           Stackage.CompleteBuild
 import           Stackage.Curator.UploadIndex
 import           Stackage.DiffPlans

--- a/stackage-curator.cabal
+++ b/stackage-curator.cabal
@@ -117,7 +117,6 @@ executable stackage-curator
                      , stackage-curator
                      , optparse-applicative >= 0.11
                      , optparse-simple
-                     , stackage-cli
                      , system-filepath
                      , http-client
                      , http-client-tls
@@ -130,8 +129,8 @@ executable stackage-build-plan
   hs-source-dirs:      app
   build-depends:       base
                      , stackage-curator
-                     , stackage-cli
                      , optparse-applicative
+                     , optparse-simple
                      , text
                      , aeson
   default-language:    Haskell2010


### PR DESCRIPTION
Passes tests with the current stack.yaml (ghc 7.10), as well as the following (ghc 8.0):

```
resolver: nightly-2016-06-15
packages:
- '.'
extra-deps:
- stackage-install-0.1.1.1
- store-0.2.0.0
- store-core-0.2.0.0
- th-utilities-0.1.1.0
```