### PR TITLE
ShowBuildPlan: export ToInstall

### DIFF
--- a/Stackage/ShowBuildPlan.hs
+++ b/Stackage/ShowBuildPlan.hs
@@ -15,6 +15,7 @@ module Stackage.ShowBuildPlan
     , setShellCommands
     , abstractCommands
     , simpleCommands
+    , ToInstall (..)
     , getBuildPlan
     , toSimpleText
     , toShellScript


### PR DESCRIPTION
this allows better use of getBuildPlan outside stackage-curator