### PR TITLE
ShowBuildPlan: change getBuildPlan and add getPackagesToInstall

### DIFF
--- a/app/stackage-build-plan.hs
+++ b/app/stackage-build-plan.hs
@@ -20,7 +20,7 @@ main = do
         "Calculate and print (in different formats) Stackage build plans"
         options
         empty
-    tis <- getBuildPlan set $ map (mkPackageName . T.pack) packages
+    tis <- getPackagesToInstall set $ map (mkPackageName . T.pack) packages
     TLIO.putStr $ render set tis
   where
     options = (,,)


### PR DESCRIPTION
- getBuildPlan now returns whole BuildPlan
- getPackagesToInstall replaces old getBuildPlan

This does make a breaking API change though: dunno if you prefer to avoid that, though I could not think of a simple natural naming-scheme that would avoid that (other than `getFullBuildPlan` perhaps). If it looks okay maybe the version could be bumped?