### PR TITLE
Update to Cabal-2.0.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,22 @@ addons:
   apt:
     packages:
     - libgmp-dev
+    - alex-3.1.7
+    sources:
+    - hvr-ghc
 
 before_install:
 # stack
 - mkdir -p ~/.local/bin
-- export PATH=$HOME/.local/bin:$PATH
+- export PATH=/opt/alex/3.1.7/bin:$HOME/.local/bin:$PATH
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
 script:
 - mkdir -p to-travis
 - stack --version
-- stack --no-terminal --install-ghc install alex
+# TODO: alex is installed from hvr-ghc to remove circular dependency with Cabal extra-dep
+# uncomment and remove alex addon after removing Cabal-2.0 extra-dep from stack.yaml
+#- stack --no-terminal --install-ghc build alex
 - stack --no-terminal --install-ghc test --copy-bins --local-bin-path to-travis
 - bzip2 to-travis/stackage-curator
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,8 @@ before_install:
 script:
 - mkdir -p to-travis
 - stack --version
-- stack --no-terminal build alex
-- stack --no-terminal build store
-- stack --no-terminal test --install-ghc --copy-bins --local-bin-path to-travis
+- stack --no-terminal --install-ghc install alex
+- stack --no-terminal --install-ghc test --copy-bins --local-bin-path to-travis
 - bzip2 to-travis/stackage-curator
 
 cache:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,10 @@
 resolver: lts-9.0
 packages:
 - .
-- location: https://github.com/snoyberg/cabal/archive/19e43a8d767dbb43fa14ba373ba09429bbb73355.zip
-  extra-dep: true
-  subdirs:
-  - Cabal
-
+extra-deps:
+- Cabal-2.0.0.2
+flags:
+  Cabal:
+    parsec: true
 ghc-options:
   Cabal: "-O2"

--- a/stackage-curator.cabal
+++ b/stackage-curator.cabal
@@ -41,7 +41,7 @@ library
                        Stackage.Types
   build-depends:       base >= 4 && < 5
                      , containers
-                     , Cabal-snoy >= 2.0 && < 2.1
+                     , Cabal >= 2.0 && < 2.1
                      , tar >= 0.3
                      , zlib
                      , bytestring
@@ -141,7 +141,7 @@ test-suite spec
                      , QuickCheck
                      , text
                      , classy-prelude-conduit
-                     , Cabal-snoy
+                     , Cabal
                      , yaml
                      , containers
                      , http-client


### PR DESCRIPTION
I'm using `stackage-curator` snapshot dependency with Cabal-2 support, and `Cabal-snoy` fork causes me some troubles. This patch switches to vanilla Cabal-2 dependency and fixes related Travis errors.

Updates:

- Switch to latest Cabal-2.0.0.2
- Stack builds Cabal with flag `parsec: true` \cc @snoyberg I saw you enabled this flag in your [Cabal-snoy](https://github.com/snoyberg/cabal/commit/19e43a8d767dbb43fa14ba373ba09429bbb73355) fork 
- Travis installs `alex` from apt to remove circular dependency with Cabal extra-dep