### PR TITLE
Add a check for mistyped or otherwise unknown package names

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.15.2.0
+
+* Add a check for mistyped or otherwise unknown package names [#47](https://github.com/fpco/stackage-curator/issues/47)
+
 ## 0.15.1.0
 
 * `skipped-haddocks`

--- a/Stackage/BuildPlan.hs
+++ b/Stackage/BuildPlan.hs
@@ -37,15 +37,16 @@ newBuildPlan :: MonadIO m
              -> BuildConstraints
              -> m BuildPlan
 newBuildPlan eallCabalHashesCommit packagesOrig packagesLatest bc@BuildConstraints {..} = liftIO $ do
-    let unknownPackages = bcPackages `Set.difference` Map.keysSet packagesLatest
-    forM_ (NE.nonEmpty $ setToList unknownPackages) $ \pkgNames -> do
-        putStrLn "Couldn't find the following package names in the package index:"
-        forM_ pkgNames $ \p -> do
-            let mmaintainer = unMaintainer <$> pcMaintainer (bcPackageConstraints p)
-                maintainerT = fromMaybe "" ((++ ")") . (" (" ++) <$> mmaintainer)
-            putStrLn ("- " ++ display p ++ maintainerT)
-        putStrLn "Please check them for typos."
-        error "Exiting due to unknown packages"
+    unless (Map.null packagesLatest) $ do
+        let unknownPackages = bcPackages `Set.difference` Map.keysSet packagesLatest
+        forM_ (NE.nonEmpty $ setToList unknownPackages) $ \pkgNames -> do
+            putStrLn "Couldn't find the following package names in the package index:"
+            forM_ pkgNames $ \p -> do
+                let mmaintainer = unMaintainer <$> pcMaintainer (bcPackageConstraints p)
+                    maintainerT = fromMaybe "" ((++ ")") . (" (" ++) <$> mmaintainer)
+                putStrLn ("- " ++ display p ++ maintainerT)
+            putStrLn "Please check them for typos."
+            error "Exiting due to unknown packages"
 
     let newReleased = mapMaybe checkReleased $ mapToList bcTellMeWhenItsReleased
         checkReleased (name, expectedVersion) =

--- a/Stackage/BuildPlan.hs
+++ b/Stackage/BuildPlan.hs
@@ -19,6 +19,7 @@ module Stackage.BuildPlan
     ) where
 
 import           Control.Monad.State.Strict      (execState, get, put)
+import qualified Data.List.NonEmpty              as NE
 import qualified Data.Map                        as Map
 import qualified Data.Set                        as Set
 import qualified Distribution.Compiler
@@ -36,6 +37,16 @@ newBuildPlan :: MonadIO m
              -> BuildConstraints
              -> m BuildPlan
 newBuildPlan eallCabalHashesCommit packagesOrig packagesLatest bc@BuildConstraints {..} = liftIO $ do
+    let unknownPackages = bcPackages `Set.difference` Map.keysSet packagesLatest
+    forM_ (NE.nonEmpty $ setToList unknownPackages) $ \pkgNames -> do
+        putStrLn "Couldn't find the following package names in the package index:"
+        forM_ pkgNames $ \p -> do
+            let mmaintainer = unMaintainer <$> pcMaintainer (bcPackageConstraints p)
+                maintainerT = fromMaybe "" ((++ ")") . (" (" ++) <$> mmaintainer)
+            putStrLn ("- " ++ display p ++ maintainerT)
+        putStrLn "Please check them for typos."
+        error "Exiting due to unknown packages"
+
     let newReleased = mapMaybe checkReleased $ mapToList bcTellMeWhenItsReleased
         checkReleased (name, expectedVersion) =
             case lookup name packagesLatest of

--- a/stackage-curator.cabal
+++ b/stackage-curator.cabal
@@ -1,5 +1,5 @@
 name:                stackage-curator
-version:             0.15.1.0
+version:             0.15.2.0
 synopsis:            Tools for curating Stackage bundles
 description:         Please see <http://www.stackage.org/package/stackage-curator> for a description and documentation.
 homepage:            https://github.com/fpco/stackage-curator

--- a/test/Stackage/BuildPlanSpec.hs
+++ b/test/Stackage/BuildPlanSpec.hs
@@ -63,7 +63,7 @@ check readPlanFile getPlans = do
     bc <- readPlanFile man
     plans <- getPlans bc
     allCabalHashesCommit <- getAllCabalHashesCommit
-    bp <- newBuildPlan allCabalHashesCommit plans mempty bc
+    bp <- newBuildPlan allCabalHashesCommit plans testLatestPackages bc
     let bs = Y.encode bp
         ebp' = Y.decodeEither bs
 
@@ -150,3 +150,9 @@ testBuildConstraints _ =
     decodeFileEither fp >>=
     either throwIO toBC
     where fp = "test/test-build-constraints.yaml"
+
+-- | Test package set with versions.
+testLatestPackages :: Map PackageName Version
+testLatestPackages =
+     Map.fromList [ (mkPackageName n, mkVersion [0, 0, 0])
+                  | n <- ["bar", "foo", "mu"] ]


### PR DESCRIPTION
Fixes #47.

Sample output for the current build-constraints.yaml:

```
➤ stack exec -- stackage-curator check
Loading default build constraints
Creating build plan
Determining target package versions
Parsing package descriptions
Couldn't find the following package names in the package index:
- compiler-errors (Dmitry Ivanov <ethercrow@gmail.com> @ethercrow)
- fpretty (Olaf Chitil <oc@kent.ac.uk> @OlafChitil)
- quadtree (Ashley Moni ashley.moni1@gmail.com @AshleyMoni)
- thermonuc (Rob O'Callahan ropoctl@gmail.com @rcallahan)
- threads-extra (Jonathan Fischoff <jonathangfischoff@gmail.com>)
Please check them for typos.
stackage-curator: Exiting due to unknown packages
CallStack (from HasCallStack):
  error, called at ./Stackage/BuildPlan.hs:48:9 in stackage-curator-0.15.1.0-LUDqG9mlvhNLS3m1BBWok1:Stackage.BuildPlan
```