### PR TITLE
Don't pass --flags to Setup unless there are flags

### DIFF
--- a/Stackage/PerformBuild.hs
+++ b/Stackage/PerformBuild.hs
@@ -448,7 +448,7 @@ singleBuild pb@PerformBuild {..} registeredPackages SingleBuild {..} = do
         tell' $ "--docdir=" ++ pack (pbDocDir pb </> unpack namever)
         tell' $ "--htmldir=" ++ pack (pbDocDir pb </> unpack namever)
         tell' $ "--haddockdir=" ++ pack (pbDocDir pb </> unpack namever)
-        tell' $ "--flags=" ++ flags
+        when (not $ null flags) $ tell' $ "--flags=" ++ flags
         when (pbEnableLibProfiling && pcEnableLibProfile) $
             tell' "--enable-library-profiling"
         when pbEnableExecDyn $ tell' "--enable-executable-dynamic"


### PR DESCRIPTION
This probably used to work, but it doesn't seem to now.