### PR TITLE
Use recommended method to obtain tool dependencies

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Use Cabal.Simple.BuildToolDepends.getAllToolDependencies to compute the tools field of SimpleDesc [#52](https://github.com/fpco/stackage-curator/issues/52)
+
 ## 0.15.2.0
 
 * Add a check for mistyped or otherwise unknown package names [#47](https://github.com/fpco/stackage-curator/issues/47)

--- a/Stackage/PackageIndex.hs
+++ b/Stackage/PackageIndex.hs
@@ -38,6 +38,7 @@ import           Distribution.PackageDescription
 import           Distribution.PackageDescription.Parse (ParseResult (..),
                                                         parsePackageDescription)
 import           Distribution.ParseUtils               (PError)
+import           Distribution.Simple.BuildToolDepends  (getAllToolDependencies)
 import           Distribution.System                   (Arch, OS)
 import           Stackage.Prelude
 import           Stackage.GithubPings
@@ -191,10 +192,11 @@ gpdToSpd raw gpd = SimplifiedPackageDescription
     simpleTest = helper noModules testBuildInfo
     simpleBench = helper noModules benchmarkBuildInfo
 
+    helper :: (a ->  Set Text) -> (a -> BuildInfo) -> a -> SimplifiedComponentInfo
     helper getModules' getBI x = SimplifiedComponentInfo
         { sciBuildTools = map
           (\(ExeDependency _ name' range) -> (ExeName $ pack $ unUnqualComponentName name', range))
-          (buildToolDepends $ getBI x)
+          (getAllToolDependencies (packageDescription gpd) (getBI x))
         , sciModules = getModules' x
         }
 


### PR DESCRIPTION
Addresses #50 . This is documented as the recommended way to obtain tool
dependencies in
https://hackage.haskell.org/package/Cabal-2.0.0.2/docs/Distribution-Simple-BuildToolDepends.html

I've tested this by running
```
stackage-curator create-plan --target nightly-2017-10-03 --plan-file test.yaml
```
with and without this patch, and observing that the `language-c/description/tools` key is empty without the patch, and contains happy and alex with the patch.