### PR TITLE
Fix cabal constraints

### DIFF
--- a/Stackage/PackageIndex.hs
+++ b/Stackage/PackageIndex.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveFunctor      #-}

--- a/Stackage/PackageIndex.hs
+++ b/Stackage/PackageIndex.hs
@@ -110,10 +110,6 @@ data SimplifiedPackageDescription = SimplifiedPackageDescription
     }
     deriving Generic
 
-#if !MIN_VERSION_base(4, 9, 0)
-deriving instance Generic Version
-#endif
-
 instance Store SimplifiedPackageDescription
 instance Store a => Store (CondTree ConfVar [Dependency] a)
 instance Store a => Store (CondBranch ConfVar [Dependency] a)

--- a/stackage-curator.cabal
+++ b/stackage-curator.cabal
@@ -54,7 +54,7 @@ library
                      , utf8-string
 
                      , conduit-extra
-                     , classy-prelude-conduit >= 0.12
+                     , classy-prelude-conduit >= 1
                      , text
                      , system-fileio
                      , system-filepath
@@ -122,7 +122,7 @@ executable stackage-build-plan
                      , optparse-applicative
                      , optparse-simple
                      , text
-                     , aeson
+                     , aeson >= 1
   default-language:    Haskell2010
   other-extensions:    TemplateHaskell
 


### PR DESCRIPTION
Fix build constraints

## classy-prelude-conduit >=1

```
/home/dbushev/projects/Aviora/stackage-curator/Stackage/Curator/UploadDocs.hs:113:18: Not in scope: ‘askRunBase’

/home/dbushev/projects/Aviora/stackage-curator/Stackage/Curator/UploadDocs.hs:114:20:
    Not in scope: ‘runConcurrently’

/home/dbushev/projects/Aviora/stackage-curator/Stackage/Curator/UploadDocs.hs:115:13:
    Not in scope: data constructor ‘Concurrently’

/home/dbushev/projects/Aviora/stackage-curator/Stackage/Curator/UploadDocs.hs:117:28:
    Not in scope: data constructor ‘Concurrently’

/home/dbushev/projects/Aviora/stackage-curator/Stackage/Curator/UploadDocs.hs:240:14:
    Not in scope: type constructor or class ‘MonadBaseUnlift’
```

## aeson >= 1 

```
/home/dbushev/projects/Aviora/stackage-curator/app/stackage-build-plan.hs:4:18:
    Could not find module ‘Data.Aeson.Text’
    Perhaps you meant
      Data.Aeson.TH (from aeson-0.11.3.0@aeson_FkJ0QVv64AF4wUlW9izgcW)
      Data.Aeson.Types (from aeson-0.11.3.0@aeson_FkJ0QVv64AF4wUlW9izgcW)
    Use -v to see a list of the files searched for.
```