### PR TITLE
Update core packages to include Cabal & deps

### DIFF
--- a/Stackage/CorePackages.hs
+++ b/Stackage/CorePackages.hs
@@ -105,7 +105,8 @@ addDeepDepends name@(unPackageName -> name') = do
 -- Precondition: GHC global package database has only core packages, and GHC
 -- ships with just a single version of each packages.
 getCorePackages :: IO (Map PackageName Version)
-getCorePackages = flip execStateT mempty $ mapM_ (addDeepDepends . mkPackageName)
+getCorePackages = flip execStateT mempty $ do
+  mapM_ (addDeepDepends . mkPackageName)
     [ "ghc"
     , "Cabal"
     {-
@@ -113,6 +114,8 @@ getCorePackages = flip execStateT mempty $ mapM_ (addDeepDepends . mkPackageName
     , "haskell98"
     -}
     ]
+  -- don't count Cabal itself as a core package, just its deps
+  modify $ deleteMap (mkPackageName "Cabal")
 
 -- | A list of executables that are shipped with GHC.
 getCoreExecutables :: IO (Set ExeName)

--- a/Stackage/CorePackages.hs
+++ b/Stackage/CorePackages.hs
@@ -107,6 +107,7 @@ addDeepDepends name@(unPackageName -> name') = do
 getCorePackages :: IO (Map PackageName Version)
 getCorePackages = flip execStateT mempty $ mapM_ (addDeepDepends . mkPackageName)
     [ "ghc"
+    , "Cabal"
     {-
     , "haskell2010"
     , "haskell98"


### PR DESCRIPTION
I think this is the thing to do for ghc 8.4+. Not so sure it will work with LTS <= 11, though.