### PR TITLE
Do not report failing bench dependencies when benches are disabled

### DIFF
--- a/Stackage/PerformBuild.hs
+++ b/Stackage/PerformBuild.hs
@@ -338,8 +338,10 @@ singleBuild pb@PerformBuild {..} registeredPackages SingleBuild {..} = do
                 . withTSem pcNonParallelBuild sbSem
         withUnpacked <- wfd libComps buildLibrary
 
-        wfd testComps (runTests withUnpacked)
-        wfd benchComps (buildBenches withUnpacked)
+        when pbEnableTests $
+          wfd testComps (runTests withUnpacked)
+        when pbEnableBenches $
+          wfd benchComps (buildBenches withUnpacked)
 
     pname = piName sbPackageInfo
     pident = PackageIdentifier pname (ppVersion $ piPlan sbPackageInfo)


### PR DESCRIPTION
It's become apparent that even though we pass `--skip-benches` to `stackage-curator make-bundle`, it still tries to build benchmarks and complains when it cannot do that, e.g. (from a real log):

```
lifted-async: DependencyFailed (PackageName "criterion") (pending: 203, failures: 448)
```

In the example above, only benchmark of `lifted-async` depends on `criterion`, and yet in spite of us passing `--skip-benches` this is reported.