### PR TITLE
Prefer globally-installed binaries over those from Haskell packages.

### DIFF
--- a/src/Stackage/PerformBuild.hs
+++ b/src/Stackage/PerformBuild.hs
@@ -274,7 +274,7 @@ performBuild' pb@PerformBuild {..} = withBuildDir $ \builddir -> do
 
     fixEnv (p, x)
         -- Thank you Windows having case-insensitive environment variables...
-        | toUpper p == "PATH" = (p, pbBinDir pb ++ pathSep : x)
+        | toUpper p == "PATH" = (p, x ++ pathSep : pbBinDir pb)
         | otherwise = (p, x)
 
     allowedEnv (k, _) = k `notMember` bannedEnvs


### PR DESCRIPTION
This helps resolve conflicts when a package defines an executable
that conflicts with the name of an existing binary.  In particular,
this should help resolve commercialhaskell/stackage#3931.

It also makes stackage-curator's custom logic behave more like the
`stack` executable:
https://hackage.haskell.org/package/rio-0.0.0.0/docs/src/RIO-Process.html#augmentPath