### PR TITLE
Hack up a way to handle internal libs

### DIFF
--- a/src/Stackage/PackageIndex.hs
+++ b/src/Stackage/PackageIndex.hs
@@ -99,6 +99,7 @@ data SimplifiedPackageDescription = SimplifiedPackageDescription
     , spdVersion :: Version
     , spdCabalFileInfo :: CabalFileInfo
     , spdCondLibrary :: Maybe (CondTree ConfVar [Dependency] SimplifiedComponentInfo)
+    , spdCondSubLibraries :: [(String, CondTree ConfVar [Dependency] SimplifiedComponentInfo)]
     , spdCondExecutables :: [(String, CondTree ConfVar [Dependency] SimplifiedComponentInfo)]
     , spdCondTestSuites :: [(String, CondTree ConfVar [Dependency] SimplifiedComponentInfo)]
     , spdCondBenchmarks :: [(String, CondTree ConfVar [Dependency] SimplifiedComponentInfo)]
@@ -168,6 +169,7 @@ gpdToSpd raw gpd = SimplifiedPackageDescription
                     ]
         }
     , spdCondLibrary = mapCondTree simpleLib <$> condLibrary gpd
+    , spdCondSubLibraries = map unqual $ map (fmap $ mapCondTree simpleLib) $ condSubLibraries gpd
     , spdCondExecutables = map unqual $ map (fmap $ mapCondTree simpleExe) $ condExecutables gpd
     , spdCondTestSuites = map unqual $ map (fmap $ mapCondTree simpleTest) $ condTestSuites gpd
     , spdCondBenchmarks = map unqual $ map (fmap $ mapCondTree simpleBench) $ condBenchmarks gpd


### PR DESCRIPTION
It ain't perfect, but it seems to work. Addresses #68.

I tested this by installing stackage-curator from this branch, and running `./check` on the stackage repo, with `htoml-megaparsec` added to the build plan. The build plan succeeds, and I spot checked in the check-plan.yaml file that the internal lib's dependencies were added to the "library" component's dependencies.

```
        unordered-containers:
          components:
          - library
          - test-suite
          range: ! '>=0.2'
```

Note that the lib itself doesn't declare a direct dep on `unordered-containers`:
http://hackage.haskell.org/package/htoml-megaparsec-2.1.0.3/htoml-megaparsec.cabal

I also verified that `./Setup build` is still all it takes to build `htoml-megaparsec`. I did this like so:

```
$ stack build --dependencies-only
$ stack exec ghc Setup
$ ./Setup --package-db="$PKG_DB_1" --package-db="$PKG_DB_2" --package-db="$PKG_DB_3" configure --user
$ ./Setup build
```

`main = defaultMain` (what we're already doing) already knows how to handle internal libs, so I don't think the build process needs any adjustment.

While I'd have rather put effort into "stackage-curator using stack", this seemed a quicker way for now to get stackage-curator working with internal libs.